### PR TITLE
Refactor Nix configurations for modularity and add new host gigi

### DIFF
--- a/common/configuration.nix
+++ b/common/configuration.nix
@@ -1,0 +1,107 @@
+# common/configuration.nix
+{ pkgs, ... }: {
+  environment.systemPackages = [
+    pkgs.fzf
+    pkgs.go
+    pkgs.jq
+    pkgs.mas
+    (pkgs.nerdfonts.override { fonts = [ "Meslo" ]; })
+    pkgs.rustup
+    pkgs.starship
+    pkgs.vim
+    pkgs.wget
+    pkgs.yq
+    pkgs.zoxide
+  ];
+
+  services.nix-daemon.enable = true;
+
+  nix.settings.experimental-features = "nix-command flakes";
+
+  system.stateVersion = 4;
+
+  nixpkgs.hostPlatform = "aarch64-darwin";
+
+  system = {
+    defaults = {
+      NSGlobalDomain = {
+        AppleInterfaceStyle = "Dark";
+        InitialKeyRepeat = 15;
+        KeyRepeat = 2;
+        AppleKeyboardUIMode = 3;
+        "com.apple.mouse.tapBehavior" = 1;
+        "com.apple.trackpad.scaling" = 2.5;
+        AppleShowAllExtensions = true;
+        AppleShowAllFiles = true;
+        "com.apple.sound.beep.feedback" = 1;
+      };
+      CustomUserPreferences = {
+          "com.microsoft.VSCode" = { "ApplePressAndHoldEnabled" = false; };
+      };
+      dock = {
+        autohide = true;
+        "show-recents" = false;
+        "wvous-bl-corner" = 2; # Mission Control
+        "wvous-br-corner" = 4; # Desktop
+        "wvous-tl-corner" = 3; # Application Windows
+        "wvous-tr-corner" = 10; # Display Sleep
+      };
+      finder = {
+        AppleShowAllExtensions = true;
+        AppleShowAllFiles = true;
+      };
+      menuExtraClock.ShowSeconds = true;
+      trackpad = {
+        Clicking = true;
+      };
+    };
+    keyboard = {
+      enableKeyMapping = true;
+      remapCapsLockToEscape = true;
+    };
+  };
+
+  programs.zsh = {
+    enable = true;
+    interactiveShellInit = ''
+      eval "$(zoxide init zsh)"
+    '';
+    promptInit = ''
+      eval "$(starship init zsh)"
+    '';
+  };
+
+  environment.shellAliases = {
+    gco = "git checkout";
+    grs = "git restore --staged";
+    gs = "git status";
+    gsl = "git log --oneline --graph --decorate";
+    ll = "ls -lah";
+  };
+
+  homebrew = {
+    enable = true;
+    global.autoUpdate = false;
+    onActivation.cleanup = "zap";
+    brews = [
+      "md5sha1sum"
+    ];
+    casks = [
+      "1password",
+      "1password-cli",
+      "alfred",
+      "dropbox",
+      "firefox",
+      "iterm2",
+      "signal",
+      "spotify",
+      "tailscale",
+      "telegram",
+      "visual-studio-code",
+      "whatsapp"
+    ];
+    masApps = {
+      "Divvy" = 413857545;
+    };
+  };
+}

--- a/flow/flake.nix
+++ b/flow/flake.nix
@@ -9,183 +9,37 @@
 
   outputs = inputs@{ self, nix-darwin, nixpkgs }:
   let
+    commonConfiguration = import ../common/configuration.nix;
     configuration = { pkgs, ... }: {
-      # List packages installed in system profile. To search by name, run:
-      # $ nix-env -qaP | grep wget
-      environment.systemPackages = [
-        # pkgs.atuin
-        # pkgs.bat
-        # pkgs.starship
-        pkgs.fzf
-        pkgs.go
-        pkgs.jq
-        pkgs.mas
-        (pkgs.nerdfonts.override { fonts = [ "Meslo" ]; })
-        pkgs.rustup
-        pkgs.starship
-        pkgs.vim
-        pkgs.wget
-        pkgs.yq
-        pkgs.zoxide
-      ];
-
-      # TODO: configure iterm with Meslo nerdfont
-      #       Installed into macOS using `open /nix/store/qqg5b6vhh2hvl8km98l7d579c0si0djg-nerdfonts-3.0.2/share/fonts/truetype/NerdFonts/MesloLGSNerdFont-Regular.ttf`
-
-      # Required by many of the systemPackages
-      # nixpkgs.config.allowUnfree = true;
-
-      # Manage homebrew with nix-darwin
-      homebrew.enable = true;
-
-      # prevent homebrew auto-update when invoked via CLI
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-homebrew.global.autoUpdate
-      homebrew.global.autoUpdate = false;
-
-      # Uninstall brews and Zap casks that are not present in this config
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-homebrew.onActivation.cleanup
-      homebrew.onActivation.cleanup = "zap";
-
-      homebrew.brews = [
-        "md5sha1sum" # would install coreutils via nix but it has a bunch of binaries I don't want eg. chmod
-      ];
-
-      # Homebrew install these casks
+      # flow-specific homebrew casks
       homebrew.casks = [
-         "1password"          # 1Password wants to be installed /Applications (not /Applicatons/Nix Apps)
-         "1password-cli"      # because 1Password is installed this way
-         "alfred"             # not available in nixpkgs
-         "authy"              # not available in nixpkgs
-         "backblaze"          # not available in nixpkgs
-         "boop"
-         "choosy"             # not available in nixpkgs # TODO: figure out how to set default browser (to Choosy)
-         "clocker"            # not available in nixpkgs
-         "dropbox"            # not available in nixpkgs
-         "firefox"            # not available in nixpkgs
-         "gimp"               # failed to install via nixpkgs
-         "iterm2"             # TODO: install with nixpkgs
-         "rewind"             # not available in nixpkgs
-         "signal"             # not available in nixpkgs
-         "spotify"            # TODO: install with nixpkgs
-         "tailscale"          # TODO: couldn't find app after install with nixpkgs
-         "telegram"           # not available in nixpkgs
-         "visual-studio-code" # TODO: install with nixpkgs
-         "whatsapp"           # not available in nixpkgs
+        "authy"              # not in common
+        "backblaze"          # not in common
+        "boop"               # not in common (was in flow, not petite)
+        "choosy"             # not in common
+        "clocker"            # not in common
+        "gimp"               # not in common (was in flow, not petite)
+        "rewind"             # not in common
       ];
 
       # To install backblaze run:
       #   $ read -r VERSION INSTALLER <<<$(brew info --json=v2 --cask backblaze | jq -r '.casks[0] | [.version, (.artifacts[] | select(.installer) | .installer[0].manual)] | @tsv') && open "$(brew --caskroom)/backblaze/$VERSION/$INSTALLER"
 
-      homebrew.masApps = {
-        "Divvy" = 413857545; # valid license through MAS
-      };
+      # TODO: configure iterm with Meslo nerdfont
+      #       Installed into macOS using `open /nix/store/qqg5b6vhh2hvl8km98l7d579c0si0djg-nerdfonts-3.0.2/share/fonts/truetype/NerdFonts/MesloLGSNerdFont-Regular.ttf`
+      #       (nerdfonts package is in commonConfiguration)
 
       # TODO: configure divvy with:
       #    /Library/Preferences/com.mizage.Divvy.plist
+      #    (Divvy MAS app is in commonConfiguration)
 
-      # Auto upgrade nix package and the daemon service.
-      services.nix-daemon.enable = true;
-      # nix.package = pkgs.nix;
+      # TODO: configure Choosy & license?
+      #       ~/Library/Application\ Support/Choosy/behaviours.plist
+      #       ~/Library/Preferences/com.choosyosx.Choosy.plist
 
-      # Necessary for using flakes on this system.
-      nix.settings.experimental-features = "nix-command flakes";
+      # TODO: configure Alfred & license?
 
-      # Create /etc/zshrc that loads the nix-darwin environment.
-      programs.zsh.enable = true;  # default shell on catalina
-      # programs.fish.enable = true;
-
-      # set shell aliases
-      environment.shellAliases = {
-        gco = "git checkout";
-        grs = "git restore --staged";
-        gs = "git status";
-        gsl = "git log --oneline --graph --decorate";
-        ll = "ls -lah";
-      };
-
-      # set up /etc/zshrc
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-programs.zsh.interactiveShellInit
-      programs.zsh.interactiveShellInit = ''
-        eval "$(zoxide init zsh)"
-      '';
-
-      # configure the prompt to use starship
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-programs.zsh.promptInit
-      programs.zsh.promptInit = ''
-        eval "$(starship init zsh)"
-      '';
-
-      # Used for backwards compatibility, please read the changelog before changing.
-      # $ darwin-rebuild changelog
-      system.stateVersion = 4;
-
-      # The platform the configuration will be used on.
-      nixpkgs.hostPlatform = "aarch64-darwin";
-
-      # Dark Mode
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.NSGlobalDomain.AppleInterfaceStyle
-      system.defaults.NSGlobalDomain.AppleInterfaceStyle = "Dark";
-
-      # Hot Corners
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.dock.wvous-bl-corner
-      system.defaults.dock.wvous-bl-corner = 2;  # Mission Control
-      system.defaults.dock.wvous-br-corner = 4;  # Desktop
-      system.defaults.dock.wvous-tl-corner = 3;  # Application Windows
-      system.defaults.dock.wvous-tr-corner = 10; # Display Sleep
-
-      # Hide the Dock automatically
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.dock.autohide
-      system.defaults.dock.autohide = true;
-
-      # Hide recent applications in Dock
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.dock.show-recents
-      system.defaults.dock.show-recents = false;
-
-      # Allow keys to be remapped
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.keyboard.enableKeyMapping
-      system.keyboard.enableKeyMapping = true;
-
-      # Keyboard Remap Caps Lock to Escape
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.keyboard.remapCapsLockToEscape
-      system.keyboard.remapCapsLockToEscape = true;
-
-      # Faster key repeat rates
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.NSGlobalDomain.InitialKeyRepeat
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.NSGlobalDomain.KeyRepeat
-      system.defaults.NSGlobalDomain.InitialKeyRepeat = 15;
-      system.defaults.NSGlobalDomain.KeyRepeat = 2;
-
-      # Use keyboard to navigate
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.NSGlobalDomain.AppleKeyboardUIMode
-      system.defaults.NSGlobalDomain.AppleKeyboardUIMode = 3;
-
-      # Tap to click
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.NSGlobalDomain._com.apple.mouse.tapBehavior_
-      system.defaults.NSGlobalDomain."com.apple.mouse.tapBehavior" = 1;
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.trackpad.Clicking
-      system.defaults.trackpad.Clicking = true;
-
-      # Speed up the trackpad
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.NSGlobalDomain._com.apple.trackpad.scaling_
-      system.defaults.NSGlobalDomain."com.apple.trackpad.scaling" = 2.5;
-
-      # Finder: Always show file extensions
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.NSGlobalDomain.AppleShowAllExtensions
-      system.defaults.NSGlobalDomain.AppleShowAllExtensions = true;
-
-      # Finder: Show hidden files
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.NSGlobalDomain.AppleShowAllFiles
-      system.defaults.NSGlobalDomain.AppleShowAllFiles = true;
-
-      # Toolbar: Show seconds in clock
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.menuExtraClock.ShowSeconds
-      system.defaults.menuExtraClock.ShowSeconds = true;
-
-      # Sound: Play feedback when volume is changed
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.NSGlobalDomain._com.apple.sound.beep.feedback_
-      system.defaults.NSGlobalDomain."com.apple.sound.beep.feedback" = 1;
-
-      # https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.CustomUserPreferences
+      # flow-specific CustomUserPreferences
       system.defaults.CustomUserPreferences = {
         # Show Bluetooth, Focus Mode, and Sound in Menu Bar
         # TODO: confirm these work
@@ -200,24 +54,18 @@
         #   "ActivityAdvertisingAllowed" = false;
         #   "ActivityReceivingAllowed" = false;
         # };
-        # fix key repeat in VSCode
-        "com.microsoft.VSCode" = { "ApplePressAndHoldEnabled" = false; };
       };
 
-      # TODO: figure out how to set default browser (to Choosy)
-
-      # TODO: configure Choosy & license?
-      #       ~/Library/Application\ Support/Choosy/behaviours.plist
-      #       ~/Library/Preferences/com.choosyosx.Choosy.plist
-
-      # TODO: configure Alfred & license?
+      # Optional: uncomment if flow specifically needs unfree packages, e.g. for backblaze installer
+      # Required by many of the systemPackages
+      # nixpkgs.config.allowUnfree = true;
     };
   in
   {
     # Build darwin flake using:
     # $ darwin-rebuild build --flake .#flow
     darwinConfigurations."flow" = nix-darwin.lib.darwinSystem {
-      modules = [ configuration ];
+      modules = [ commonConfiguration configuration ];
     };
 
     # Expose the package set, including overlays, for convenience.

--- a/gigi/flake.lock
+++ b/gigi/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1689281837,
+        "narHash": "sha256-msgwgot2/hxXzlpYltIZ7boAqBkN8XejNOhBJ07q3FY=",
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "rev": "c806a73609e77f0c446fdad5d3ea6ca3b7ae6e5f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1689413807,
+        "narHash": "sha256-exuzOvOhGAEKWQKwDuZAL4N8a1I837hH5eocaTcIbLc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46ed466081b9cad1125b11f11a2af5cc40b942c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/gigi/flake.nix
+++ b/gigi/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "gigi macOS system flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nix-darwin.url = "github:LnL7/nix-darwin";
+    nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = inputs@{ self, nix-darwin, nixpkgs }:
+  let
+    commonConfiguration = import ../common/configuration.nix;
+    # gigi specific configuration (empty for now, as it should be similar to flow/petite)
+    configuration = { pkgs, ... }: {
+      # Add any gigi-specific settings here in the future.
+      # For example, if gigi needs a specific cask:
+      # homebrew.casks = [ "some-gigi-specific-cask" ];
+    };
+  in
+  {
+    darwinConfigurations."gigi" = nix-darwin.lib.darwinSystem {
+      modules = [ commonConfiguration configuration ];
+    };
+    darwinPackages = self.darwinConfigurations."gigi".pkgs;
+  };
+}

--- a/petite/flake.nix
+++ b/petite/flake.nix
@@ -9,183 +9,47 @@
 
   outputs = inputs@{ self, nix-darwin, nixpkgs }:
   let
+    commonConfiguration = import ../common/configuration.nix;
     configuration = { pkgs, ... }: {
-      # List packages installed in system profile. To search by name, run:
-      # $ nix-env -qaP | grep wget
-      environment.systemPackages = [
-        # pkgs.atuin
-        # pkgs.bat
-        # pkgs.starship
-        pkgs.fzf
-        pkgs.go
-        pkgs.jq
-        pkgs.mas
-        (pkgs.nerdfonts.override { fonts = [ "Meslo" ]; })
-        pkgs.rustup
-        pkgs.starship
-        pkgs.vim
-        pkgs.wget
-        pkgs.yq
-        pkgs.zoxide
+      # petite-specific homebrew casks
+      homebrew.casks = [
+        "google-chrome"      # not in common
+        "zoom"               # not in common
       ];
 
-      # TODO: configure iterm with Meslo nerdfont
-      #       Installed into macOS using `open /nix/store/qqg5b6vhh2hvl8km98l7d579c0si0djg-nerdfonts-3.0.2/share/fonts/truetype/NerdFonts/MesloLGSNerdFont-Regular.ttf`
+      # petite-specific zsh login shell init
+      programs.zsh.loginShellInit = ''
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+      '';
 
-      # Auto upgrade nix package and the daemon service.
-      services.nix-daemon.enable = true;
-      # nix.package = pkgs.nix;
-
-      # Necessary for using flakes on this system.
-      nix.settings.experimental-features = "nix-command flakes";
-
-      # Set Git commit hash for darwin-version.
+      # System configuration revision
       system.configurationRevision = self.rev or self.dirtyRev or null;
 
-      # Used for backwards compatibility, please read the changelog before changing.
-      # $ darwin-rebuild changelog
-      system.stateVersion = 4;
-
-      # The platform the configuration will be used on.
-      nixpkgs.hostPlatform = "aarch64-darwin";
-
-      system = {
-        defaults = {
-          CustomUserPreferences = {
-            "com.microsoft.VSCode" = { "ApplePressAndHoldEnabled" = false; };
-          };
-          dock = {
-            appswitcher-all-displays = true;
-            autohide = true;
-            show-recents = false;
-
-            # hot corners
-            # BL: Application Windows
-            # BR: Desktop
-            # TL: Mission Control
-            # TR: Put Display to Sleep
-            wvous-bl-corner = 3;
-            wvous-br-corner = 4;
-            wvous-tl-corner = 2;
-            wvous-tr-corner = 10;
-          };
-
-          finder = {
-            AppleShowAllExtensions = true;
-            AppleShowAllFiles = true;
-            ShowPathbar = true;
-            FXPreferredViewStyle = "Nlsv";
-          };
-
-          menuExtraClock.ShowSeconds = true;
- 
-          NSGlobalDomain = {
-            AppleInterfaceStyle = "Dark";
-            InitialKeyRepeat = 15;
-            KeyRepeat = 2;
-            AppleKeyboardUIMode = 3;
-            "com.apple.mouse.tapBehavior" = 1;
-            "com.apple.trackpad.scaling" = 2.5;
-            AppleShowAllExtensions = true;
-            AppleShowAllFiles = true;
-            "com.apple.sound.beep.feedback" = 1;
-          };
-
-          trackpad = {
-            Clicking = true;
-          };
+      # petite-specific system defaults
+      system.defaults = {
+        dock = {
+          appswitcher-all-displays = true; # petite specific
+          # Override common hot corners to match petite's original settings
+          wvous-bl-corner = 3; # Application Windows (common was 2 for Mission Control)
+          wvous-tl-corner = 2; # Mission Control (common was 3 for Application Windows)
         };
-
-        keyboard = {
-          enableKeyMapping = true;
-          remapCapsLockToEscape = true;
+        finder = {
+          ShowPathbar = true;           # petite specific
+          FXPreferredViewStyle = "Nlsv"; # petite specific
         };
       };
 
-
-      # Create /etc/zshrc that loads the nix-darwin environment.
-      programs.zsh = {
-        enable = true;
-
-        # set up /etc/zprofile
-        # https://daiderd.com/nix-darwin/manual/index.html#opt-programs.zsh.loginShellInit
-        loginShellInit = ''
-          eval "$(/opt/homebrew/bin/brew shellenv)"
-        '';
-
-        # set up /etc/zshrc
-        # https://daiderd.com/nix-darwin/manual/index.html#opt-programs.zsh.interactiveShellInit
-        interactiveShellInit = ''
-          eval "$(zoxide init zsh)"
-        '';
-
-        # configure the prompt to use starship
-        # https://daiderd.com/nix-darwin/manual/index.html#opt-programs.zsh.promptInit
-        promptInit = ''
-          eval "$(starship init zsh)"
-        '';
-        };
-
-      # set shell aliases
-      environment.shellAliases = {
-        gco = "git checkout";
-        grs = "git restore --staged";
-        gs = "git status";
-        gsl = "git log --oneline --graph --decorate";
-        ll = "ls -lah";
-      };
-
-      homebrew = {
-        enable = true;
-        global.autoUpdate = false;
-        onActivation.cleanup = "zap";
-
-        brews = [
-          "md5sha1sum"
-        ];
-
-        casks = [
-          "1password"          # 1Password wants to be installed /Applications (not /Applicatons/Nix Apps)
-          "1password-cli"      # because 1Password is installed this way
-          "alfred"             # not available in nixpkgs
-          # "backblaze"          # not available in nixpkgs
-          # "choosy"             # not available in nixpkgs # TODO: figure out how to set default browser (to Choosy)
-          # "clocker"            # not available in nixpkgs
-          "dropbox"            # not available in nixpkgs
-          "firefox"            # not available in nixpkgs
-          "google-chrome"      # not available in nixpkgs
-          # "gimp"               # failed to install via nixpkgs
-          "iterm2"             # TODO: install with nixpkgs
-          # "rewind"             # not available in nixpkgs
-          "signal"             # not available in nixpkgs
-          "spotify"            # TODO: install with nixpkgs
-          "tailscale"          # TODO: couldn't find app after install with nixpkgs
-          "telegram"           # not available in nixpkgs
-          "visual-studio-code" # TODO: install with nixpkgs
-          "whatsapp"           # not available in nixpkgs
-          "zoom"
-        ];
-
-        masApps = {
-          "Divvy" = 413857545; # valid license through MAS
-        };
-
-        # TODO: configure divvy with:
-        #    /Library/Preferences/com.mizage.Divvy.plist
-      };
-
-      # found in a blog post, unsure if it works.
-      # system.activationScripts.postUserActivation.text = ''
-      #   # Following line should allow us to avoid a logout/login cycle
-      #   /System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
-      # '';
+      # TODO: configure divvy with: /Library/Preferences/com.mizage.Divvy.plist (reminder)
+      #       (Divvy MAS app is in commonConfiguration)
+      # TODO: configure iterm with Meslo nerdfont
+      #       (nerdfonts package is in commonConfiguration)
     };
   in
   {
     # Build darwin flake using:
     # $ darwin-rebuild build --flake .#petite
     darwinConfigurations."petite" = nix-darwin.lib.darwinSystem {
-      modules = [ configuration ];
+      modules = [ commonConfiguration configuration ];
     };
 
     # Expose the package set, including overlays, for convenience.


### PR DESCRIPTION
This change introduces a common Nix configuration module to reduce duplication across different host setups.

Key changes:
- Created `common/configuration.nix` containing shared settings for system packages, homebrew, zsh, Nix, and system defaults.
- Refactored `flow/flake.nix` and `petite/flake.nix` to import and utilize the common configuration, leaving only host-specific settings in their respective files.
- Added a new host `gigi` with its own `flake.nix` that also uses the common configuration. `gigi/flake.lock` was initialized from flow's lock file.

This restructuring simplifies managing multiple Nix host configurations and makes it easier to maintain consistency and add new hosts.